### PR TITLE
Use AdjustToMinimumContentsLengthWithIcon which works in Qt5 and Qt6

### DIFF
--- a/src/napari_toolkit/widgets/combobox.py
+++ b/src/napari_toolkit/widgets/combobox.py
@@ -36,7 +36,7 @@ def setup_combobox(
 
     if placeholder is not None:
         _widget.setPlaceholderText(placeholder)
-    _widget.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLength)
+    _widget.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon)
     return connect_widget(
         layout,
         _widget,

--- a/src/napari_toolkit/widgets/layer_select.py
+++ b/src/napari_toolkit/widgets/layer_select.py
@@ -116,7 +116,7 @@ def setup_layerselect(
     _widget = QLayerSelect(layer_type=layer_type)
     if viewer:
         _widget.connect(viewer)
-    _widget.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLength)
+    _widget.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon)
     return connect_widget(
         layout,
         _widget,


### PR DESCRIPTION
As noted here: https://github.com/MIC-DKFZ/napari-nninteractive/issues/7#issuecomment-2741753488
Qt6 doesn't have `AdjustToMinimumContentsLength` just `AdjustToMinimumContentsLengthWithIcon`
See: https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QComboBox.html#PySide6.QtWidgets.QComboBox.SizeAdjustPolicy
Qt5 has both.
So this PR uses `AdjustToMinimumContentsLengthWithIcon` for compatibility.
Tested locally with pyqt5 and pyqt6, I see no differences in the layout in napari-nninteractive, which is consistent with the docs I linked above.
