### PR TITLE
Update layer_select.py to support multiple layer types

### DIFF
--- a/src/napari_toolkit/widget_gallery.py
+++ b/src/napari_toolkit/widget_gallery.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import napari
-from napari.layers import Image, Labels
+from napari.layers import Image, Labels, Shapes
 from napari.viewer import Viewer
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QTreeWidgetItem, QVBoxLayout, QWidget
@@ -247,6 +247,10 @@ class GalleryWidget(QWidget):
         _ = setup_label(layout_ls, "Select an Labels Layer")
         _ = setup_layerselect(
             layout_ls, self._viewer, Labels, function=lambda: print("QLayerSelect")
+        )
+        _ = setup_label(layout_ls, "Select an Labels or Shapes Layer")
+        _ = setup_layerselect(
+            layout_ls, self._viewer, [Labels, Shapes], function=lambda: print("QLayerSelect")
         )
 
         # Colorbar


### PR DESCRIPTION
This PR adds support for specifying multiple layer types for a single layer_select QComboBox.

For an example see the changes to the widget gallery. 

The core idea is that maybe a plugin may want to support both Label layers as well as Shapes or Points layers for a similar purpose.
